### PR TITLE
Fix Issue #81 parsing error of config.yml

### DIFF
--- a/lib/lapis_lazuli/world/config.rb
+++ b/lib/lapis_lazuli/world/config.rb
@@ -116,11 +116,14 @@ module WorldModule
 
       # Try all files in order
       files.each do |file|
-        begin
-          # Try to load a config file
-          return self.load_config_from_file(file)
-        rescue
-          # Do nothing, load the next file
+        # Check if files exist
+        if File.file?(file)
+          begin
+            # Try to load a config file
+            return self.load_config_from_file(file)
+          rescue Exception => e
+            raise e
+          end
         end
       end
     end
@@ -175,9 +178,8 @@ module WorldModule
           json = File.read(filename)
           data = JSON.parse(json)
         end
-      rescue RuntimeError => err
-        # Can't help you
-        raise "Error loading file: #{filename} #{err}"
+      rescue Exception => e
+        raise "Error loading file: #{filename} #{e}"
       end
 
       # Fix up empty files


### PR DESCRIPTION
Now correctly shows an error message whenever an error occurs trying to load a config file.
This includes YAML.load_file() parsing errors with linenumbers